### PR TITLE
added exception for KeyError when no running ngrok tunnel exists

### DIFF
--- a/dbtunnel/tunnels.py
+++ b/dbtunnel/tunnels.py
@@ -167,7 +167,10 @@ class DbTunnel(abc.ABC):
                                     ):
         self._share = True
         if kill_existing_processes is True:
-            pkill("ngrok")
+            try:
+                pkill("ngrok")
+            except KeyError:
+                print("no running tunnels to kill")
         from dbtunnel.ngrok import NgrokTunnel
         ngrok_tunnel = NgrokTunnel(self._port,
                                    ngrok_tunnel_auth_token,


### PR DESCRIPTION
Got an error when there's no running ngrok tunnel to kill so I added the KeyError exception to the tunnels logic
I have no way ootb to test it so double check me