### PR TITLE
Add support for Ray model serving 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -346,3 +346,5 @@ scratch
 .chainlit
 chainlit.md
 .dbtunnel
+
+.python-version

--- a/dbtunnel/__init__.py
+++ b/dbtunnel/__init__.py
@@ -90,5 +90,10 @@ class AppTunnels:
         from dbtunnel.arize_phoenix_ui import ArizePhoenixUITunnel
         return ArizePhoenixUITunnel(port)
 
+    @staticmethod
+    def ray(app, port: int = 8080):
+        from dbtunnel.ray import RayAppTunnel
+        return RayAppTunnel(app, port)
+    
 
 dbtunnel = AppTunnels()

--- a/dbtunnel/ray.py
+++ b/dbtunnel/ray.py
@@ -33,7 +33,7 @@ class RayAppTunnel(DbTunnel):
 
         async def start():
             http_options: HTTPOptions = HTTPOptions(host="0.0.0.0", port=self._port)
-            proxy_location: ProxyLocation = ProxyLocation(self._proxy_settings.url_base_path.rstrip("/"))
+            proxy_location: ProxyLocation = ProxyLocation(self._proxy_settings.proxy_url)
             serve.start(http_options=http_options, proxy_location=proxy_location)
             _: DeploymentHandle = serve.run(self._ray, route_prefix="/", blocking=True)
 

--- a/dbtunnel/ray.py
+++ b/dbtunnel/ray.py
@@ -10,40 +10,34 @@ class RayAppTunnel(DbTunnel):
     def _imports(self):
         try:
             from fastapi import FastAPI
-            import uvicorn
-            import nest_asyncio
             import ray
-
+            import nest_asyncio
         except ImportError as e:
-            self._log.info("ImportError: Make sure you have ray, fastapi and nest_asyncio installed;"
-                  "pip install ray, fastapi nest_asyncio uvicorn")
+            self._log.info(
+                "ImportError: Make sure you have ray, fastapi and nest_asyncio installed;"
+                "pip install ray, fastapi nest_asyncio uvicorn"
+            )
             raise e
 
     def _run(self):
         self.display()
         self._log.info("Starting server...")
-        import ray
+
         from ray import serve
         from ray.serve.handle import DeploymentHandle
         from ray.serve.config import HTTPOptions
 
-
         import nest_asyncio
+
         nest_asyncio.apply()
-        
-        # uvicorn.run(app, host="0.0.0.0", port=self._port)
-        # Start the server
+
         async def start():
             http_options: HTTPOptions = HTTPOptions(host="0.0.0.0", port=self._port)
             serve.start(http_options=http_options)
-            #https://adb-dp-984752964297111.11.azuredatabricks.net/driver-proxy/o/984752964297111/0502-204747-70x3cktp/8080/
-            _: DeploymentHandle = (
-                serve.run(self._ray, route_prefix="/", blocking=True)
-            )
-        
+            _: DeploymentHandle = serve.run(self._ray, route_prefix="/", blocking=True)
 
-        # Run the asyncio event loop instead of uvloop to enable re entrance
         import asyncio
+
         self._log.info(f"Use this link: \n{self._proxy_settings.proxy_url}")
         asyncio.run(start())
 

--- a/dbtunnel/ray.py
+++ b/dbtunnel/ray.py
@@ -28,6 +28,9 @@ class RayAppTunnel(DbTunnel):
         from ray.serve.config import HTTPOptions
 
 
+        import nest_asyncio
+        nest_asyncio.apply()
+        
         # uvicorn.run(app, host="0.0.0.0", port=self._port)
         # Start the server
         async def start():

--- a/dbtunnel/ray.py
+++ b/dbtunnel/ray.py
@@ -25,7 +25,7 @@ class RayAppTunnel(DbTunnel):
 
         from ray import serve
         from ray.serve.handle import DeploymentHandle
-        from ray.serve.config import HTTPOptions
+        from ray.serve.config import HTTPOptions, ProxyLocation
 
         import nest_asyncio
 
@@ -33,7 +33,8 @@ class RayAppTunnel(DbTunnel):
 
         async def start():
             http_options: HTTPOptions = HTTPOptions(host="0.0.0.0", port=self._port)
-            serve.start(http_options=http_options)
+            proxy_location: ProxyLocation = ProxyLocation(url_prefix=self._proxy_settings.url_base_path.rstrip("/"))
+            serve.start(http_options=http_options, proxy_location=proxy_location)
             _: DeploymentHandle = serve.run(self._ray, route_prefix="/", blocking=True)
 
         import asyncio

--- a/dbtunnel/ray.py
+++ b/dbtunnel/ray.py
@@ -33,7 +33,7 @@ class RayAppTunnel(DbTunnel):
 
         async def start():
             http_options: HTTPOptions = HTTPOptions(host="0.0.0.0", port=self._port)
-            proxy_location: ProxyLocation = ProxyLocation(url_prefix=self._proxy_settings.url_base_path.rstrip("/"))
+            proxy_location: ProxyLocation = ProxyLocation(self._proxy_settings.url_base_path.rstrip("/"))
             serve.start(http_options=http_options, proxy_location=proxy_location)
             _: DeploymentHandle = serve.run(self._ray, route_prefix="/", blocking=True)
 

--- a/dbtunnel/ray.py
+++ b/dbtunnel/ray.py
@@ -37,7 +37,7 @@ class RayAppTunnel(DbTunnel):
             http_options: HTTPOptions = HTTPOptions(host="0.0.0.0", port=self._port)
             serve.start(http_options=http_options)
             _: DeploymentHandle = (
-                serve.run(self._ray, route_prefix=self._proxy_settings.url_base_path.rstrip("/"), is_blocking=True)
+                serve.run(self._ray, route_prefix=self._proxy_settings.url_base_path.rstrip("/"), blocking=True)
             )
         
 

--- a/dbtunnel/ray.py
+++ b/dbtunnel/ray.py
@@ -24,20 +24,13 @@ class RayAppTunnel(DbTunnel):
         from ray import serve
         from ray.serve.config import HTTPOptions
 
-        import nest_asyncio
-        nest_asyncio.apply()
-
-        # uvicorn.run(app, host="0.0.0.0", port=self._port)
-        # Start the server
-        async def start():
+        def start():
             http_options: HTTPOptions = HTTPOptions(host="0.0.0.0", port=self._port)
             serve.start(http_options=http_options)
-            await serve.run(self._ray, route_prefix=self._proxy_settings.url_base_path.rstrip("/"))
+            serve.run(self._ray, route_prefix=self._proxy_settings.url_base_path.rstrip("/"))
 
-        # Run the asyncio event loop instead of uvloop to enable re entrance
-        import asyncio
         self._log.info(f"Use this link: \n{self._proxy_settings.proxy_url}")
-        asyncio.run(start())
+        start()
 
     def _display_url(self):
         # must end with a "/" for it to not redirect

--- a/dbtunnel/ray.py
+++ b/dbtunnel/ray.py
@@ -33,7 +33,7 @@ class RayAppTunnel(DbTunnel):
 
         async def start():
             http_options: HTTPOptions = HTTPOptions(host="0.0.0.0", port=self._port)
-            proxy_location: ProxyLocation = ProxyLocation(self._proxy_settings.proxy_url)
+            proxy_location: ProxyLocation = ProxyLocation.HeadOnly
             serve.start(http_options=http_options, proxy_location=proxy_location)
             _: DeploymentHandle = serve.run(self._ray, route_prefix="/", blocking=True)
 

--- a/dbtunnel/ray.py
+++ b/dbtunnel/ray.py
@@ -13,6 +13,7 @@ class RayAppTunnel(DbTunnel):
             import uvicorn
             import nest_asyncio
             import ray
+
         except ImportError as e:
             self._log.info("ImportError: Make sure you have ray, fastapi and nest_asyncio installed;"
                   "pip install ray, fastapi nest_asyncio uvicorn")
@@ -21,16 +22,26 @@ class RayAppTunnel(DbTunnel):
     def _run(self):
         self.display()
         self._log.info("Starting server...")
+        import ray
         from ray import serve
+        from ray.serve.handle import DeploymentHandle
         from ray.serve.config import HTTPOptions
 
-        def start():
+
+        # uvicorn.run(app, host="0.0.0.0", port=self._port)
+        # Start the server
+        async def start():
             http_options: HTTPOptions = HTTPOptions(host="0.0.0.0", port=self._port)
             serve.start(http_options=http_options)
-            serve.run(self._ray, route_prefix=self._proxy_settings.url_base_path.rstrip("/"))
+            _: DeploymentHandle = (
+                serve.run(self._ray, route_prefix=self._proxy_settings.url_base_path.rstrip("/"), is_blocking=True)
+            )
+        
 
+        # Run the asyncio event loop instead of uvloop to enable re entrance
+        import asyncio
         self._log.info(f"Use this link: \n{self._proxy_settings.proxy_url}")
-        start()
+        asyncio.run(start())
 
     def _display_url(self):
         # must end with a "/" for it to not redirect

--- a/dbtunnel/ray.py
+++ b/dbtunnel/ray.py
@@ -24,6 +24,8 @@ class RayAppTunnel(DbTunnel):
         from ray import serve
         from ray.serve.config import HTTPOptions
 
+        import nest_asyncio
+        nest_asyncio.apply()
 
         # uvicorn.run(app, host="0.0.0.0", port=self._port)
         # Start the server

--- a/dbtunnel/ray.py
+++ b/dbtunnel/ray.py
@@ -36,8 +36,9 @@ class RayAppTunnel(DbTunnel):
         async def start():
             http_options: HTTPOptions = HTTPOptions(host="0.0.0.0", port=self._port)
             serve.start(http_options=http_options)
+            #https://adb-dp-984752964297111.11.azuredatabricks.net/driver-proxy/o/984752964297111/0502-204747-70x3cktp/8080/
             _: DeploymentHandle = (
-                serve.run(self._ray, route_prefix=self._proxy_settings.url_base_path.rstrip("/"), blocking=True)
+                serve.run(self._ray, route_prefix="/", blocking=True)
             )
         
 

--- a/dbtunnel/ray.py
+++ b/dbtunnel/ray.py
@@ -1,0 +1,42 @@
+from dbtunnel.tunnels import DbTunnel
+
+
+class RayAppTunnel(DbTunnel):
+
+    def __init__(self, ray, port: int = 8080):
+        super().__init__(port, flavor="ray")
+        self._ray = ray
+
+    def _imports(self):
+        try:
+            from fastapi import FastAPI
+            import uvicorn
+            import nest_asyncio
+            import ray
+        except ImportError as e:
+            self._log.info("ImportError: Make sure you have ray, fastapi and nest_asyncio installed;"
+                  "pip install ray, fastapi nest_asyncio uvicorn")
+            raise e
+
+    def _run(self):
+        self.display()
+        self._log.info("Starting server...")
+        from ray import serve
+        from ray.serve.config import HTTPOptions
+
+
+        # uvicorn.run(app, host="0.0.0.0", port=self._port)
+        # Start the server
+        async def start():
+            http_options: HTTPOptions = HTTPOptions(host="0.0.0.0", port=self._port)
+            serve.start(http_options=http_options)
+            await serve.run(self._ray, route_prefix=self._proxy_settings.url_base_path.rstrip("/"))
+
+        # Run the asyncio event loop instead of uvloop to enable re entrance
+        import asyncio
+        self._log.info(f"Use this link: \n{self._proxy_settings.proxy_url}")
+        asyncio.run(start())
+
+    def _display_url(self):
+        # must end with a "/" for it to not redirect
+        return f'<a href="{self._proxy_settings.proxy_url}">Click to go to {self._flavor} App!</a>'

--- a/dbtunnel/tunnels.py
+++ b/dbtunnel/tunnels.py
@@ -92,7 +92,7 @@ def get_cloud_proxy_settings(cloud: str, org_id: str, cluster_id: str, port: int
 
 Flavor = Literal[
     "gradio", "fastapi", "nicegui", "streamlit", "stable-diffusion-ui", "bokeh", "flask", "dash", "solara",
-    "code-server", "chainlit", "shiny-python", "uvicorn", "arize-phoenix"]
+    "code-server", "chainlit", "shiny-python", "uvicorn", "arize-phoenix", "ray"]
 
 
 def get_current_username() -> str:

--- a/examples/ray/ray.py
+++ b/examples/ray/ray.py
@@ -1,0 +1,43 @@
+# Databricks notebook source
+# MAGIC %pip install dbtunnel[ray] transformers 
+# MAGIC dbutils.library.restartPython()
+
+# COMMAND ----------
+
+ngrok_api_key: str = dbutils.secrets.get("fieldeng", "ngrok-api-key")
+ngrok_tunnel_auth_token: str = dbutils.secrets.get("fieldeng", "ngrok-tunnel-auth-token")
+
+# COMMAND ----------
+
+from ray import serve
+from ray.serve.deployment import Application
+
+from transformers import pipeline
+
+@serve.deployment(num_replicas=2, )
+class SentimentAnalysis:
+
+  def __init__(self):
+    self._classifier = pipeline("sentiment-analysis")
+
+  def __call__(self, request) -> str:
+    input_text: str = request.query_params["input_text"]
+    return self._classifier(input_text)[0]["label"]
+  
+  
+app: Application = SentimentAnalysis.bind() #noqa: F821
+ 
+  
+
+# COMMAND ----------
+
+from dbtunnel import dbtunnel
+
+(
+  dbtunnel.ray(app, port=8080)
+    .inject_auth()
+    .share_to_internet_via_ngrok(
+        ngrok_api_token=ngrok_api_key, 
+        ngrok_tunnel_auth_token=ngrok_tunnel_auth_token)
+    .run()
+)

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
         "ray": [
             "ray",
             "fastapi",
-            "uvicorn",
+            "pyngrok",
         ],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,12 @@ setup(
         ],
         "arize-phoenix": [
             "arize-phoenix"
-        ]
+        ],
+        "ray": [
+            "ray",
+            "fastapi",
+            "uvicorn",
+        ],
     },
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ setup(
         "ray": [
             "ray",
             "fastapi",
-            "pyngrok",
         ],
     },
     classifiers=[


### PR DESCRIPTION
This PR adds support for ray apps to dbtunnel.

This aims to cover use cases around use ray to serve REST endpoints.  
The below example (included in examples/) demonstrates model serving.


```python

ngrok_api_key: str = dbutils.secrets.get("fieldeng", "ngrok-api-key")
ngrok_tunnel_auth_token: str = dbutils.secrets.get("fieldeng", "ngrok-tunnel-auth-token")

from ray import serve
from ray.serve.deployment import Application

from transformers import pipeline

@serve.deployment(num_replicas=2, )
class SentimentAnalysis:

  def __init__(self):
    self._classifier = pipeline("sentiment-analysis")

  def __call__(self, request) -> str:
    input_text: str = request.query_params["input_text"]
    return self._classifier(input_text)[0]["label"]
  
  
app: Application = SentimentAnalysis.bind() #noqa: F821

from dbtunnel import dbtunnel

(
  dbtunnel.ray(app, port=8080)
    .inject_auth()
    .share_to_internet_via_ngrok(
        ngrok_api_token=ngrok_api_key, 
        ngrok_tunnel_auth_token=ngrok_tunnel_auth_token)
    .run()
)
```